### PR TITLE
Replace Claude Sonnet 4.5 with newest-in-tier models in demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,13 @@ To illustrate these concepts, this project uses [LiteLLM](https://docs.litellm.a
 
 ### AWS Configuration
 1. **AWS Account**: An active account with [Amazon Bedrock access](https://docs.aws.amazon.com/bedrock/latest/userguide/setting-up.html). For the account sharding demo, you'll need access to two AWS accounts, both configured with all the requirements described in items 2-4 below. Enable the following models in each account:
-    - Anthropic Claude Sonnet 4.5, Claude Sonnet 4.6, and Claude Haiku 4.5
+    - Anthropic Claude Sonnet 4.6 and Claude Haiku 4.5
 2. **AWS Profile & Region**: The project reads AWS configuration from `config/config.yaml`. First, update the profile name and Region in `config/config.yaml` to match your setup, then ensure your [AWS profile credentials are configured](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) before running the demos. The gateway and demo scripts will automatically use the profile and Region specified in `config/config.yaml`. For multi-account deployments, follow [AWS multi-account best practices](https://docs.aws.amazon.com/whitepapers/latest/organizing-your-aws-environment/organizing-your-aws-environment.html).
    - A sample least-privilege IAM policy needed to run all the demos is provided in [`iam/policy.json`](iam/policy.json). Replace `<REGION>` and `<ACCOUNT_ID>` placeholders with your specific values before applying. Note that the values might change if you modify the default configuration values in `config/config.yaml`.
 3. **Enable Amazon Bedrock cross-Region inference**: Configure [cross-Region inference](https://docs.aws.amazon.com/bedrock/latest/userguide/cross-Region-inference.html) in your AWS account to allow automatic distribution of requests across multiple AWS Regions for improved availability and throughput.
 4. **Enable CloudWatch Logging for Bedrock**: Enable [model invocation logging](https://docs.aws.amazon.com/bedrock/latest/userguide/model-invocation-logging.html) in Amazon Bedrock and create the CloudWatch log group in the same Region as your Bedrock configuration. Set the log group name in `config/config.yaml` under `aws.bedrock_log_group_name` (default: "BedrockModelInvocation"). Ensure your AWS profile has the required permissions:
         - `bedrock:InvokeModel` on the following model families:
             - `us.anthropic.claude-sonnet-4-6*`
-            - `us.anthropic.claude-sonnet-4-5-*`
             - `us.anthropic.claude-haiku-4-5-*`
             - `us.amazon.nova-*`
         - `logs:StartQuery`, `logs:GetQueryResults`, `logs:DescribeQueries`, `logs:DescribeLogGroups` for CloudWatch Logs
@@ -187,8 +186,8 @@ This demo demonstrates how LiteLLM's `simple-shuffle` routing strategy distribut
 
 | Model | Max RPM | Type | Purpose |
 |-------|---------|------|---------|
-| us.anthropic.claude-sonnet-4-5-20250929-v1:0 | 3 | Primary | Load balanced instance 1 |
-| us.anthropic.claude-sonnet-4-6 | 3 | Primary | Load balanced instance 2 |
+| us.anthropic.claude-sonnet-4-6 | 3 | Primary | Load balanced instance 1 |
+| us.anthropic.claude-haiku-4-5-20251001-v1:0 | 3 | Primary | Load balanced instance 2 |
 | us.anthropic.claude-haiku-4-5-20251001-v1:0 | 25 | Fallback | Overflow capacity |
 
 When sending 10 concurrent requests, the simple-shuffle algorithm randomly distributes them across both primary models (6 RPM combined capacity). Once these models reach their limits, the remaining 4 requests automatically route to the fallback model, ensuring all requests are served successfully.
@@ -208,8 +207,7 @@ Successful:         10
 Failed:             0
 
 Model Distribution:
-  us.anthropic.claude-haiku-4-5-20251001-v1:0       :  4 requests ( 40.0%)
-  us.anthropic.claude-sonnet-4-5-20250929-v1:0       :  3 requests ( 30.0%)
+  us.anthropic.claude-haiku-4-5-20251001-v1:0       :  7 requests ( 70.0%)
   us.anthropic.claude-sonnet-4-6         :  3 requests ( 30.0%)
 
 [19:08:08.723] LOAD BALANCING WORKING: Requests distributed across multiple models!
@@ -217,15 +215,15 @@ Model Distribution:
 
 ### 5. LiteLLM Consumer/Quota Isolation
 
-This demo shows how quota isolation prevents "noisy neighbor" problems in multi-tenant environments. Each consumer uses the same underlying Claude Sonnet 4.5 model but with independent rate limiting buckets at the gateway level:
+This demo shows how quota isolation prevents "noisy neighbor" problems in multi-tenant environments. Each consumer uses the same underlying Claude Sonnet 4.6 model but with independent rate limiting buckets at the gateway level:
 
 ![Consumer/Quota Isolation Architecture](imgs/demo-quota.jpg)
 
 | Consumer | Model | Max RPM | Type | Purpose |
 |----------|-------|---------|------|---------|
-| Consumer A | us.anthropic.claude-sonnet-4-5-20250929-v1:0 | 3 | Noisy | Simulates aggressive consumer |
-| Consumer B | us.anthropic.claude-sonnet-4-5-20250929-v1:0 | 10 | Normal | Regular application workload |
-| Consumer C | us.anthropic.claude-sonnet-4-5-20250929-v1:0 | 10 | Normal | Regular application workload |
+| Consumer A | us.anthropic.claude-sonnet-4-6 | 3 | Noisy | Simulates aggressive consumer |
+| Consumer B | us.anthropic.claude-sonnet-4-6 | 10 | Normal | Regular application workload |
+| Consumer C | us.anthropic.claude-sonnet-4-6 | 10 | Normal | Regular application workload |
 
 The demo simulates a real-world scenario where all three consumers send 5 parallel requests simultaneously. Consumer A, with its 3 RPM limit, can only process 3 requests successfully before being rate-limited. Meanwhile, Consumers B and C, with their 10 RPM quotas, successfully process all their requests. This proves that one consumer's aggressive behavior cannot affect the quality of service for other consumers.
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -53,10 +53,10 @@ model_list:
 
 - model_name: claude-sonnet-loadbalance-demo
   litellm_params:
-    model: bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0
+    model: bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0
     <<: *aws-defaults
   model_info:
-    id: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+    id: us.anthropic.claude-haiku-4-5-20251001-v1:0
   rpm: 3  # Reduced for easier demo
   tpm: 100000
 
@@ -80,21 +80,21 @@ model_list:
 # Special models for quota isolation testing - different RPM limits per consumer
 - model_name: consumer-a-model
   litellm_params:
-    model: bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0
+    model: bedrock/us.anthropic.claude-sonnet-4-6
     <<: *aws-defaults
   rpm: 3  # Noisy consumer gets limited RPM
   tpm: 30000
 
 - model_name: consumer-b-model
   litellm_params:
-    model: bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0
+    model: bedrock/us.anthropic.claude-sonnet-4-6
     <<: *aws-defaults
   rpm: 10  # Normal consumer gets higher RPM
   tpm: 100000
 
 - model_name: consumer-c-model
   litellm_params:
-    model: bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0
+    model: bedrock/us.anthropic.claude-sonnet-4-6
     <<: *aws-defaults
   rpm: 10  # Normal consumer gets higher RPM
   tpm: 100000

--- a/iam/policy.json
+++ b/iam/policy.json
@@ -10,7 +10,6 @@
       ],
       "Resource": [
         "arn:aws:bedrock:<REGION>:<ACCOUNT_ID>:inference-profile/us.anthropic.claude-sonnet-4-6",
-        "arn:aws:bedrock:<REGION>:<ACCOUNT_ID>:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
         "arn:aws:bedrock:<REGION>:<ACCOUNT_ID>:inference-profile/us.anthropic.claude-haiku-4-5-20251001-v1:0"
       ]
     },


### PR DESCRIPTION
## Context

A review of the [Amazon Bedrock model lifecycle](https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html) found that none of the demo models are on the Legacy/EOL list today — but **Claude Sonnet 4.5** is the only one with a same-tier successor (Sonnet 4.6) already shipped on Bedrock. By AWS precedent, a model is realistically put on the Legacy track once a same-tier replacement is available (e.g. Sonnet 4 launched May 2025 → Legacy Apr 2026 → EOL Oct 2026), so Sonnet 4.5 is the most likely next deprecation candidate.

This change swaps Sonnet 4.5 out so every demo runs on a **newest-in-tier** model (Sonnet 4.6, Haiku 4.5, Opus 4.6), maximizing how long the repo runs unmodified.

## Changes

- **`config/config.yaml`**: load-balancing pool 2nd instance → Haiku 4.5 (keeps two genuinely distinct backends so the per-model breakdown stays meaningful); quota-isolation consumers A/B/C → Sonnet 4.6
- **`iam/policy.json`**: drop the now-unused Sonnet 4.5 inference-profile ARN (least privilege)
- **`README.md`**: update prereqs, supported model families, and the load-balancing & quota-isolation tables/sample outputs to match

## Verification

All 5 resilience demos were run end-to-end against live Bedrock; all passed:

| Demo | Result |
|---|---|
| CRIS | 10/10 success, regional spread |
| Account sharding | 20/20 success across both accounts |
| Fallback | 3 Sonnet 4.6 + 7 Haiku 4.5, 10/10 |
| Load balancing | 3 Sonnet 4.6 + 7 Haiku 4.5, 10/10 — matches README sample |
| Quota isolation | Consumer A 60% (rate-limited), B & C 100% |

Static checks: no remaining `sonnet-4-5` references; YAML and JSON both parse.

## Note

The CRIS Opus 4.6 model (`us.anthropic.claude-opus-4-6-v1`) remains absent from `iam/policy.json` — a pre-existing gap, left out of scope here.